### PR TITLE
Employee Deletion Now Soft Deletes User

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -8,13 +8,14 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 use App\Models\Employee;
 use Illuminate\Support\Facades\Hash;
 
 class User extends Authenticatable
 {
-    use HasApiTokens, HasFactory, Notifiable;
+    use HasApiTokens, HasFactory, Notifiable, SoftDeletes;
 
     /**
      * The attributes that are mass assignable.

--- a/app/UnitsOfWork/EmployeeUOW.php
+++ b/app/UnitsOfWork/EmployeeUOW.php
@@ -114,6 +114,7 @@ class EmployeeUOW implements IEmployeeUOW
         }
         try {
             $employee->delete();
+            if(isset($employee->User) && !is_null($employee->user)) $employee->User->delete();
             return true;
         } catch (\Exception $e) {
             return false;
@@ -130,6 +131,7 @@ class EmployeeUOW implements IEmployeeUOW
         }
         try {
             $employee->restore();
+            if(!is_null($employee->User()->withTrashed()->first())) $employee->User()->withTrashed()->first()->restore();
             return true;
         } catch (\Exception $e) {
             return false;

--- a/database/migrations/2023_07_01_130000_create_users_table.php
+++ b/database/migrations/2023_07_01_130000_create_users_table.php
@@ -20,6 +20,7 @@ return new class extends Migration
             $table->boolean('manager')->nullable()->default(false);
             $table->rememberToken();
             $table->timestamps();
+            $table->softDeletes();
 
             $table->foreign('employee_id')->references('id')->on('employees');
         });


### PR DESCRIPTION
- This will essentially lock the users account imediately if their employee is delete. The account will also be reinstated should the employee be restored

![image](https://github.com/Thomashut/employeeManager/assets/11298965/e1a2bb52-645d-4afa-8e20-740d88cf6bf3)

closes #3 properly. Allowing the locking of employee account upon their soft deletion and reactivation upon their restoration